### PR TITLE
Fix(OEmbed): Updates FAU.tv API endpoint

### DIFF
--- a/includes/Player/OEmbed.php
+++ b/includes/Player/OEmbed.php
@@ -22,7 +22,7 @@ class OEmbed
                     'www.fau.tv',
                 ],
                 'home'    => 'https://www.fau.tv',
-                'api-endpoint'  => 'https://www.fau.tv/services/oembed'
+                'api-endpoint'  => 'https://api.video.uni-erlangen.de/services/oembed'
             ],
             'youtube'    => [
                 'domains'   => [
@@ -48,10 +48,10 @@ class OEmbed
         if ( empty( $url ) || ! is_string( $url ) ) {
             return '';
         }
-        
+
         $known = self::get_known_provider();
         $url = esc_url_raw( $url );
-        
+
         $searchdom = parse_url($url, PHP_URL_HOST);
         $res = '';
 
@@ -257,8 +257,8 @@ class OEmbed
                 }
             }
         }
-        
+
         return $data;
-        
+
     }
 }

--- a/rrze-video.php
+++ b/rrze-video.php
@@ -3,7 +3,7 @@
 Plugin Name:    RRZE Video
 Plugin URI:     https://github.com/RRZE-Webteam/rrze-video
 Description:    Embedding videos via a shortcode or widget based on the Plyr video player.
-Version:        5.0.7
+Version:        5.0.8
 Author:         RRZE-Webteam
 Author URI:     http://blogs.fau.de/webworking/
 License:        GNU General Public License Version 3


### PR DESCRIPTION
Updates the FAU.tv OEmbed API endpoint to the correct address.

Increments plugin version to reflect the change.
