### PR TITLE
feat(SanitizeOembed.php) - Removes host whitelist for OEmbed URLs

### DIFF
--- a/includes/Utils/SanitizeOembed.php
+++ b/includes/Utils/SanitizeOembed.php
@@ -9,14 +9,6 @@ class SanitizeOembed {
 
     private const DEFAULT_POLICY = 'drop';
 
-    private const URL_HOST_WHITELIST = [
-        'cdn.video.uni-erlangen.de',
-        'vp-cdn-balance.rrze.uni-erlangen.de',
-        'vp-cdn-balance.rrze.de',
-        'www.fau.tv',
-        'api.video.uni-erlangen.de',
-    ];
-
     private static array $URL_KEYS = [
         'file',
         'preview_image',
@@ -145,18 +137,7 @@ class SanitizeOembed {
             return '';
         }
 
-        $url = preg_replace( '#^http://#i', 'https://', $url );
-
-        $host = wp_parse_url( $url, PHP_URL_HOST );
-        if ( empty( $host ) ) {
-            return '';
-        }
-        $host = strtolower( $host );
-        if ( ! in_array( $host, self::URL_HOST_WHITELIST, true ) ) {
-            return '';
-        }
-
-        return $url;
+        return preg_replace( '#^http://#i', 'https://', $url );
     }
 
     private static function sanitize_text_nullable( $value ): string {

--- a/rrze-video.php
+++ b/rrze-video.php
@@ -3,7 +3,7 @@
 Plugin Name:    RRZE Video
 Plugin URI:     https://github.com/RRZE-Webteam/rrze-video
 Description:    Embedding videos via a shortcode or widget based on the Plyr video player.
-Version:        5.0.14
+Version:        5.0.15
 Author:         RRZE-Webteam
 Author URI:     http://blogs.fau.de/webworking/
 License:        GNU General Public License Version 3


### PR DESCRIPTION
Removes the restricted host whitelist to allow embedding videos from any source, while still enforcing HTTPS conversion. Updates plugin version to 5.0.15.
